### PR TITLE
Feature/__as__

### DIFF
--- a/lib/tfg/support/core_ext/object/as.rb
+++ b/lib/tfg/support/core_ext/object/as.rb
@@ -28,8 +28,10 @@ class Object
   #   end
   # end
   # ```
-  def as
+  def _as
     result = yield(self)
     result.nil? ? self : result
   end
+
+  alias_method :as, :_as
 end


### PR DESCRIPTION
Added `Object#__as__`, to which `Object#as` is aliased.
